### PR TITLE
Fix process order

### DIFF
--- a/src/Database/Migrations/20210119154813_create_exports.php
+++ b/src/Database/Migrations/20210119154813_create_exports.php
@@ -29,6 +29,9 @@ class CreateExports extends Migration
 
 	public function down()
 	{
+		// Drop exports
+		$this->forge->dropTable('exports');
+
 		// Restore downloads table
 		$fields = [
 			'file_id'    => ['type' => 'int', 'unsigned' => true],
@@ -43,8 +46,5 @@ class CreateExports extends Migration
 		$this->forge->addKey(['user_id', 'file_id']);
 
 		$this->forge->createTable('downloads');
-
-		// Drop exports
-		$this->forge->dropTable('exports');
 	}
 }


### PR DESCRIPTION
In rare cases where additional columns were added, the unmirrored database handling of the migration file could cause conflicts. This PR corrects the order but should require no developer input.