### PR TITLE
Improve extension handling

### DIFF
--- a/src/Entities/File.php
+++ b/src/Entities/File.php
@@ -67,21 +67,24 @@ class File extends Entity
 	 */
 	public function getExtension($method = ''): string
 	{
-		if (! $method || $method === 'type')
+		if ($this->attributes['type'] !== 'application/octet-stream')
 		{
-			if ($extension = Mimes::guessExtensionFromType($this->attributes['type']))
+			if (! $method || $method === 'type')
 			{
-				return $extension;
-			}
-		}
-
-		if (! $method || $method === 'mime')
-		{
-			if ($file = $this->getObject())
-			{
-				if ($extension = $file->guessExtension())
+				if ($extension = Mimes::guessExtensionFromType($this->attributes['type']))
 				{
 					return $extension;
+				}
+			}
+
+			if (! $method || $method === 'mime')
+			{
+				if ($file = $this->getObject())
+				{
+					if ($extension = $file->guessExtension())
+					{
+						return $extension;
+					}
 				}
 			}
 		}

--- a/src/Models/FileModel.php
+++ b/src/Models/FileModel.php
@@ -2,6 +2,7 @@
 
 use CodeIgniter\Files\File as CIFile;
 use CodeIgniter\Model;
+use Config\Mimes;
 use Tatter\Files\Entities\File;
 use Tatter\Files\Exceptions\FilesException;
 use Tatter\Thumbnails\Exceptions\ThumbnailsException;
@@ -151,7 +152,7 @@ class FileModel extends Model
 			'filename'   => $file->getFilename(),
 			'localname'  => $file->getRandomName(),
 			'clientname' => $file->getFilename(),
-			'type'       => $file->getMimeType(),
+			'type'       => Mimes::guessTypeFromExtension($file->getExtension()) ?? $file->getMimeType(),
 			'size'       => $file->getSize(),
 		];
 


### PR DESCRIPTION
Relying on MIME detection is too likely to return the "catch all" type (application/octet-stream) which in turn causes files to be identified as `.bin` when reversing the process. This PR gives client extensions a little more credibility when faced with these generics.